### PR TITLE
Fixed Edit Menu Category bug with Start and End Time

### DIFF
--- a/app/static/javascript/management.js
+++ b/app/static/javascript/management.js
@@ -1715,7 +1715,7 @@ function autofillEditMenuCategoryForm(data)
 	
 	for (i = 0; i < data.timeslots.length; i++)
 	{
-		if ( data.timeslots[i].day != "" )
+		if ( data.timeslots[i].day != null )
 		{
 			if (timeSet === false)
 			{


### PR DESCRIPTION
Checks if an element of timeslots array is null instead of the empty string