### PR TITLE
Fixed a minor error

### DIFF
--- a/app/static/javascript/order.js
+++ b/app/static/javascript/order.js
@@ -298,10 +298,11 @@ $('#PayNow').click( function()
 
 $('#cardPay').click( function()
 {
-	  SubmitOrder();
+	SubmitOrder();
 });
 
 $('#cashPay').click( function()
 {
-	  SubmitOrder();
+    localOrder.status = 'ordered';
+	SubmitOrder();
 });


### PR DESCRIPTION
Items paid with cash need to be marked "payment_accepted" by the waitstaff.

Otherwise cash submitted orders are marked as "ordered"